### PR TITLE
📝 Docs: Document api/feeds.go and establish AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Project Agents Conventions
+
+## Operational Memory
+
+* `api/` -> Contains Go serverless functions deployed on Vercel.
+  * `api/feeds.go` -> Main handler for generating Nix OS channel RSS feeds. Includes functions for downloading channel history and formatting it as feeds.
+* `vercel.json` -> Configuration for Vercel deployment, including URL rewrites.
+* `index.html` -> Static frontend served at the root URL.
+* `scripts/workspaced` -> Custom linting and formatting script wrapping `go vet` and `gofmt`. Configured to warn (exit 0) on formatting errors.
+
+## Tooling Constraints
+
+* **Task Runner:** `mise` is the required tool for managing tasks and tool versioning. It must be installed and used for all automated checks.
+* **Tool Pinning:** `mise` tools must be pinned to specific versions (e.g., Go 1.24.3). Do not use "latest" or "lts".
+* **Linting:** Use `mise run lint` for verifying code before commits.
+
+## Error Handling Guidelines
+
+* **Centralized Reporting:** All unexpected errors must be funneled through a centralized reporting mechanism if one exists.
+* **No Silent Failures:** Never leave an empty catch block or swallow errors silently. All unrecoverable errors must be reported or properly propagated.
+* **Do Not Fix Code:** Do not modify executable logic to fix issues unless explicitly instructed. Refactoring is strictly forbidden under the documentation scope.

--- a/api/feeds.go
+++ b/api/feeds.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gorilla/feeds"
 )
 
+// channels lists all valid NixOS and Nixpkgs build streams.
+// Used as an allowlist to prevent arbitrary channel requests.
 var (
     channels = []string{
         "nixos-22.05",
@@ -28,6 +30,8 @@ var (
     }
 )
 
+// CheckIfChannelExist verifies if the requested channel exists in the allowlist.
+// Prevents generating feeds for invalid or unsupported nix channels.
 func CheckIfChannelExist(channel string) bool {
     for i := 0; i < len(channels); i++ {
         if channels[i] == channel {
@@ -37,17 +41,25 @@ func CheckIfChannelExist(channel string) bool {
     return false
 }
 
+// ByDate enables sorting feed items by creation timestamp descending.
+// Needed because history files append new commits at the bottom, but RSS feeds
+// typically display newest items first.
 type ByDate []*feeds.Item
 
+// Len is part of sort.Interface.
 func (a ByDate) Len() int {
     return len(a)
 }
 
+// HistoryLine maps to a single record in a nix channel history file.
+// Each line indicates when a specific git commit was deployed to the channel.
 type HistoryLine struct {
     Commit string
     UnixTimestamp int64
 }
 
+// httpCat is a helper to fetch remote plaintext files, similar to UNIX `cat`.
+// Used primarily to pull raw commit history lists from channels.nix.gsc.io.
 func httpCat(url string) (string, error) {
     res, err := http.Get(url)
     if err != nil {
@@ -60,10 +72,14 @@ func httpCat(url string) (string, error) {
     return string(data), nil
 }
 
+// trim cleans up whitespace and carriage returns from history file lines.
 func trim(s string) string {
     return strings.Trim(s, " \n\r")
 }
 
+// fetchChannelHistory downloads and parses the full commit history for a given channel.
+// The remote file format is space-separated: "commit_hash unix_timestamp".
+// Invalid lines are logged and skipped rather than failing the entire fetch.
 func fetchChannelHistory(channel string) ([]HistoryLine, error) {
     data, err := httpCat(fmt.Sprintf("https://channels.nix.gsc.io/%s/history", channel))
     if err != nil {
@@ -89,6 +105,9 @@ func fetchChannelHistory(channel string) ([]HistoryLine, error) {
     return ret, nil
 }
 
+// generateRSSFromChannel constructs the feed metadata and converts commit history
+// into individual feed items.
+// Items older than one year are filtered out to keep feed size manageable.
 func generateRSSFromChannel(channel string) (feed *feeds.Feed, err error) {
     now := time.Now()
     feed = &feeds.Feed{}
@@ -124,14 +143,20 @@ func generateRSSFromChannel(channel string) (feed *feeds.Feed, err error) {
     return feed, nil
 }
 
+// Swap is part of sort.Interface.
 func (a ByDate) Swap(i, j int) {
     a[i], a[j] = a[j], a[i]
 }
 
+// Less is part of sort.Interface. Sorts items newest-first (descending).
 func (a ByDate) Less(i, j int) bool {
     return a[i].Created.Unix() > a[j].Created.Unix()
 }
 
+// Handler is the Vercel serverless entrypoint for all feed requests.
+// It parses the requested channel and desired feed format (rss, atom, json).
+// Sets a 1-hour cache control policy for edge caching, avoiding heavy upstream load
+// on channels.nix.gsc.io.
 func Handler(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Cache-Control", "public, max-age=3600")
     channel := r.URL.Query().Get("channel")


### PR DESCRIPTION
This PR introduces comprehensive documentation for the Vercel serverless function `api/feeds.go` and establishes the initial `AGENTS.md` file for future automated contributors.

### Key Changes
1.  **`api/feeds.go`**: Added standard Go docstrings to all exported and critical internal types/functions. The docs focus on the "why" and "flow" (e.g., explaining why `ByDate` sorts descending, why `fetchChannelHistory` skips invalid lines instead of failing, and the cache-control policy of the `Handler`).
2.  **`AGENTS.md`**: Created the project conventions file, detailing the repository structure (Operational Memory), tooling constraints (`mise` pinning), and error handling guidelines (no silent failures).

### Assumptions
*   The Go standard format (`//`) is preferred over the JS/TS example (`/** ... */`) provided in the system prompt, as per the rule: "Use the standard format used by the language you are working on."
*   Documentation scope is limited to the `api` directory for this PR to adhere to the "ONE cohesive area per PR" rule.

### Alternatives Not Chosen
*   Skipped renaming variables or refactoring complex logic in `generateRSSFromChannel` because the operational contract explicitly states: "Must not change: executable logic."

### How To Pivot
*   If the docstrings are too verbose or if they should be omitted from unexported functions (like `httpCat` or `trim`), you can request to restrict docs only to the exported `Handler` or remove specific comments.

### Next Knobs
1.  **`api/feeds.go`**: You can ask to add explicit comments tracking where the `TODO` for the content section should go.
2.  **`AGENTS.md`**: You can ask to expand the "Error Handling Guidelines" or "Tooling Constraints" if there are specific CI/CD practices you want codified.

---
*PR created automatically by Jules for task [12076360649209332588](https://jules.google.com/task/12076360649209332588) started by @lucasew*